### PR TITLE
Add Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 		}
 	},
 	"require": {
-		"illuminate/database": "^8.0",
-		"illuminate/support": "^8.0"
+		"illuminate/database": "^8.0 | ^9.0",
+		"illuminate/support": "^8.0 | ^9.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.4",


### PR DESCRIPTION
This PR updates the required composer packages to support Laravel `^9.0`.